### PR TITLE
fix: allow empty list in TekListValidator

### DIFF
--- a/immuni_common/models/marshmallow/validators.py
+++ b/immuni_common/models/marshmallow/validators.py
@@ -213,13 +213,14 @@ class TekListValidator(Validator):
         :param value: the value of the schema being validated.
         """
 
+        if len(value) == 0:
+            return
+
         # NOTE: This kind of validation (rolling_period == 144) could be performed at field level.
         #   We expect all of these validations to change in the future, so having them all together
         #   here is done on purpose to make things simpler in case of changes in validation.
         #   We would like to keep field validation more flexible as not to spread strict validation
         #   logic in many places.
-        if len(value) == 0:
-            return
 
         if any(tek.rolling_period != 144 for tek in value):
             raise ValidationError("Some rolling values are not 144.")

--- a/immuni_common/models/marshmallow/validators.py
+++ b/immuni_common/models/marshmallow/validators.py
@@ -218,6 +218,9 @@ class TekListValidator(Validator):
         #   here is done on purpose to make things simpler in case of changes in validation.
         #   We would like to keep field validation more flexible as not to spread strict validation
         #   logic in many places.
+        if len(value) == 0:
+            return
+
         if any(tek.rolling_period != 144 for tek in value):
             raise ValidationError("Some rolling values are not 144.")
 

--- a/tests/test_helpers/test_marshmallow.py
+++ b/tests/test_helpers/test_marshmallow.py
@@ -29,7 +29,11 @@ from immuni_common.models.marshmallow.fields import (
     Province,
 )
 from immuni_common.models.marshmallow.schemas import OtpDataSchema
-from immuni_common.models.marshmallow.validators import IsoDateValidator, OtpCodeValidator
+from immuni_common.models.marshmallow.validators import (
+    IsoDateValidator,
+    OtpCodeValidator,
+    TekListValidator,
+)
 
 _OTP_DATA_SERIALIZED = {"symptoms_started_on": date.today().isoformat()}
 
@@ -236,3 +240,7 @@ def test_integerbool_field(value: int) -> None:
 def test_integerbool_field_raises(value: Any) -> None:
     with raises(ValidationError):
         IntegerBoolField()._deserialize(value, None, None)
+
+
+def test_tek_key_validator_pass_if_empty() -> None:
+    TekListValidator().__call__([])


### PR DESCRIPTION
## Description

Do not raise ValueErro if the list of Teks is empty. Simply return.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Fixes #9  
