### PR TITLE
feat(logging): redacting JSON logging on Gunicorn and Celery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ To preserve functionality after every change, please ensure that all existing te
 ```bash
 poetry run pytest  \
     --cov=immuni_common \
+    --cov-branch \
     --cov-fail-under=80
 ```
 

--- a/immuni_common/core/config.py
+++ b/immuni_common/core/config.py
@@ -17,7 +17,8 @@ from immuni_common.helpers.logging import initialize_logging
 from immuni_common.models.enums import Environment, LogLevel
 
 LOG_LEVEL: LogLevel = config("LOGLEVEL", cast=LogLevel.from_env_var, default=LogLevel.INFO)
-initialize_logging(LOG_LEVEL)
+LOG_JSON_INDENT: int = config("LOG_JSON_INDENT", cast=int, default=0)
+initialize_logging(LOG_LEVEL, LOG_JSON_INDENT)
 
 # The following are supposed to be filled at Docker build time.
 GIT_BRANCH: str = config("GIT_BRANCH", default="no-release")

--- a/immuni_common/helpers/logging.py
+++ b/immuni_common/helpers/logging.py
@@ -44,7 +44,6 @@ class RedactingJsonFormatter(jsonlogger.JsonFormatter):
     }
 
     _RESERVED_ATTRS = {
-        *RESERVED_ATTRS,
         "host",  # the sanic request IP.
         "scope",  # the gunicorn field containing client IP.
     }
@@ -62,9 +61,17 @@ class RedactingJsonFormatter(jsonlogger.JsonFormatter):
         """
         super().__init__(
             fmt=" ".join(
-                sorted(self._LOGGING_ATTRS.union(logging_attrs or set()) - self._RESERVED_ATTRS)
+                sorted(
+                    self._LOGGING_ATTRS.union(
+                        set(
+                            attr
+                            for attr in logging_attrs or set()
+                            if all(reserved not in attr for reserved in self._RESERVED_ATTRS)
+                        )
+                    )
+                )
             ),
-            reserved_attrs=self._RESERVED_ATTRS,
+            reserved_attrs={*RESERVED_ATTRS, *self._RESERVED_ATTRS},
             json_indent=json_indent if json_indent else None,
         )
 

--- a/immuni_common/sanic.py
+++ b/immuni_common/sanic.py
@@ -27,6 +27,7 @@ from sanic_openapi import doc, swagger_blueprint
 from immuni_common.core import config
 from immuni_common.core.exceptions import ApiException
 from immuni_common.core.managers import BaseManagers
+from immuni_common.helpers.logging import get_sanic_logger_config
 from immuni_common.helpers.sanic import json_response
 from immuni_common.models.enums import Environment
 from immuni_common.monitoring.core import initialize_monitoring
@@ -48,7 +49,7 @@ def create_app(
     :param managers: the microservice's managers.
     :return: the created Sanic application.
     """
-    app = Sanic(__name__)
+    app = Sanic(__name__, log_config=get_sanic_logger_config(config.LOG_JSON_INDENT))
     app.config.TESTING = config.ENV == Environment.TESTING
 
     swagger_config = dict(

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,5 +14,5 @@ ignore_missing_imports = True
 [mypy-mongoengine.*,extras_mongoengine.*,bson.*,sqlalchemy.*,alembic.*,freezegun.*,pymongo.*]
 ignore_missing_imports = True
 
-[mypy-celery.*,_pytest.*,ecdsa.*,responses.*,pythonjsonlogger.*]
+[mypy-celery.*,_pytest.*,ecdsa.*,responses.*,pythonjsonlogger.*,gunicorn.*]
 ignore_missing_imports = True

--- a/tests/test_sanic.py
+++ b/tests/test_sanic.py
@@ -47,8 +47,12 @@ async def test_health_check(client: TestClient) -> None:
 async def test_ips_are_not_logged(client: TestClient, capfd: Any) -> None:
     response = await client.get("/")
     assert response.status == HTTPStatus.OK
-    out, _ = capfd.readouterr()
-    assert json.loads(out)["host"].startswith("***:")
+    out = capfd.readouterr()[0]
+    lines = [json.loads(line) for line in out.splitlines()]
+    assert any("request" in line for line in lines)
+    for line in lines:
+        if "request" in line:
+            assert line["request"].startswith("GET http://***:")
 
 
 @mark.skip(reason="Passes alone, fails when ran together with the rest")  # FIXME

--- a/tests/test_sanic.py
+++ b/tests/test_sanic.py
@@ -264,10 +264,10 @@ def test_serializer_supports_defined_types(value: Any, expected: Any) -> None:
 
 
 def test_serializer_does_not_support_undefined_types() -> None:
-    class NonSerilisable(Enum):
+    class NonSerializable(Enum):
         A = auto()
         B = auto()
 
     with raises(TypeError) as exception:
-        json.dumps(NonSerilisable.A, cls=CustomJSONEncoder)
+        json.dumps(NonSerializable.A, cls=CustomJSONEncoder)
         assert "is not JSON serializable" in str(exception)

--- a/tests/test_sanic.py
+++ b/tests/test_sanic.py
@@ -44,6 +44,13 @@ async def test_health_check(client: TestClient) -> None:
     assert response.status == HTTPStatus.OK
 
 
+async def test_ips_are_not_logged(client: TestClient, capfd: Any) -> None:
+    response = await client.get("/")
+    assert response.status == HTTPStatus.OK
+    out, _ = capfd.readouterr()
+    assert json.loads(out)["host"].startswith("***:")
+
+
 @mark.skip(reason="Passes alone, fails when ran together with the rest")  # FIXME
 async def test_metrics_at_start(client: TestClient) -> None:
     response = await client.get("/metrics")


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR implements a custom JSON formatter, which also redacts the output messages. Specifically, it obfuscates any IP and removes sensitive information form the logging `extra` fields.

It is used as part of the root logger, as well as for (i) Sanic, (ii) Gunicorn, and (iii) Celery.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #12 
- Fixes #14 
