### PR TITLE
feat: do not include swagger blueprint in production

### DIFF
--- a/immuni_common/sanic.py
+++ b/immuni_common/sanic.py
@@ -130,8 +130,7 @@ def create_app(
         app.blueprint(blueprint)
 
     if config.ENV != Environment.RELEASE:
-        # It's a good practice to avoid opening the
-        # swagger endpoints in a production environment.
+        # It's a good practice to avoid opening the swagger endpoints in a production environment.
         app.blueprint(swagger_blueprint)
 
     return app

--- a/immuni_common/sanic.py
+++ b/immuni_common/sanic.py
@@ -130,8 +130,8 @@ def create_app(
         app.blueprint(blueprint)
 
     if config.ENV != Environment.RELEASE:
-        # Swagger has some known vulnerabilities, so it's a good practice to avoid
-        # keeping the swagger endpoints open in a production environment.
+        # It's a good practice to avoid opening the
+        # swagger endpoints in a production environment.
         app.blueprint(swagger_blueprint)
 
     return app

--- a/immuni_common/sanic.py
+++ b/immuni_common/sanic.py
@@ -128,7 +128,11 @@ def create_app(
 
     for blueprint in blueprints:
         app.blueprint(blueprint)
-    app.blueprint(swagger_blueprint)
+
+    if config.ENV != Environment.RELEASE:
+        # Swagger has some known vulnerabilities, so it's a good practice to avoid
+        # keeping the swagger endpoints open in a production environment.
+        app.blueprint(swagger_blueprint)
 
     return app
 


### PR DESCRIPTION
## Description

It's a good practice to avoid opening the swagger endpoints in production environments.


## Checklist

- [X] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket: