### PR TITLE
fix: use uri_template for metrics instead of request.path

### DIFF
--- a/immuni_common/monitoring/sanic.py
+++ b/immuni_common/monitoring/sanic.py
@@ -51,7 +51,7 @@ def sanic_after_request_handler(request: Request, response: HTTPResponse) -> Non
     """
     latency = monotonic() - request[_START_TIME]
     labels = (
-        request.path,
+        request.uri_template,
         request.method,
         # NOTE: Some handlers can ignore response logic (e.g., websocket handler)
         response.status if response else 200,


### PR DESCRIPTION
## Description

Using URI templates for the "REQUESTS_LATENCY" metrics allows us to group requests with templated endpoints and perform better analysis on them. 

## Checklist

- [X] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket: