### PR TITLE
Resilience to eventual SDK inconsistencies

### DIFF
--- a/immuni_common/models/marshmallow/fields.py
+++ b/immuni_common/models/marshmallow/fields.py
@@ -135,4 +135,4 @@ class RiskScore(Integer):
     """
 
     def __init__(self) -> None:
-        super().__init__(required=True, validate=Range(min=0, max=4096))
+        super().__init__(required=True, validate=Range(min=0, max=sys.maxsize))

--- a/immuni_common/models/marshmallow/schemas.py
+++ b/immuni_common/models/marshmallow/schemas.py
@@ -80,8 +80,8 @@ class ExposureInfoSchema(Schema):
     """
 
     date = IsoDate()
-    duration = fields.Integer(required=True, validate=Range(min=0, max=1800))
-    attenuation_value = fields.Integer(required=True, validate=Range(min=0, max=255))
+    duration = fields.Integer(required=True, validate=Range(min=0, max=sys.maxsize))
+    attenuation_value = fields.Integer(required=True, validate=Range(min=0, max=sys.maxsize))
     attenuation_durations = AttenuationDurations()
     transmission_risk_level = EnumField(TransmissionRiskLevel)
     total_risk_score = RiskScore()
@@ -106,8 +106,8 @@ class ExposureDetectionSummarySchema(Schema):
     """
 
     date = IsoDate()
-    matched_key_count = fields.Integer(required=True, validate=Range(min=1, max=sys.maxsize))
-    days_since_last_exposure = fields.Integer(required=True, validate=Range(min=0, max=14))
+    matched_key_count = fields.Integer(required=True, validate=Range(min=0, max=sys.maxsize))
+    days_since_last_exposure = fields.Integer(required=True, validate=Range(min=0, max=sys.maxsize))
     attenuation_durations = AttenuationDurations()
     maximum_risk_score = RiskScore()
     exposure_info = fields.Nested(ExposureInfoSchema, many=True)


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Endpoint validation is now resilient to eventually inconsistent values returned by the Apple/Google Exposure notification SDK. 

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket: