### PR TITLE
feat: add expires_at to TemporaryExposureKey model

### DIFF
--- a/immuni_common/models/mongoengine/temporary_exposure_key.py
+++ b/immuni_common/models/mongoengine/temporary_exposure_key.py
@@ -47,6 +47,14 @@ class TemporaryExposureKey(EmbeddedDocument, Serializable):
             self.rolling_start_number * timedelta(minutes=10).total_seconds()
         )
 
+    @property
+    def expires_at(self):
+        """
+        Returns the datetime when the current key will expire (stop being used by the client to generate RPIs)
+        :return:
+        """
+        return self.created_at + timedelta(minutes=10 * self.rolling_period)
+
     def serialize(self) -> Dict[str, Any]:
         """
         Serialization method (overrides the Serializable subclass method).

--- a/immuni_common/models/mongoengine/temporary_exposure_key.py
+++ b/immuni_common/models/mongoengine/temporary_exposure_key.py
@@ -50,9 +50,9 @@ class TemporaryExposureKey(EmbeddedDocument, Serializable):
     @property
     def expires_at(self) -> datetime:
         """
-        Returns the datetime when the current key will expire
-         (when it stops being used by the client to generate RPIs)
-        :return:
+        The datetime when the current key stops being used by the client to generate RPIs.
+
+        :return: the datetime the current key expires.
         """
         return self.created_at + timedelta(minutes=10 * self.rolling_period)
 

--- a/immuni_common/models/mongoengine/temporary_exposure_key.py
+++ b/immuni_common/models/mongoengine/temporary_exposure_key.py
@@ -48,9 +48,10 @@ class TemporaryExposureKey(EmbeddedDocument, Serializable):
         )
 
     @property
-    def expires_at(self):
+    def expires_at(self) -> datetime:
         """
-        Returns the datetime when the current key will expire (stop being used by the client to generate RPIs)
+        Returns the datetime when the current key will expire
+         (when it stops being used by the client to generate RPIs)
         :return:
         """
         return self.created_at + timedelta(minutes=10 * self.rolling_period)


### PR DESCRIPTION
## Description

This PR adds the expires_at property to the TemporaryExposureKey model. This is useful to ensure we're not adding active TEKs during the ingestion processing of new batches.

## Checklist

- [X] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket:
