### PR TITLE
feat(monitoring): expose metrics from a celery context

### DIFF
--- a/immuni_common/core/config.py
+++ b/immuni_common/core/config.py
@@ -31,6 +31,8 @@ ENV: Environment = config("ENV", cast=Environment.from_env_var, default=Environm
 API_HOST: str = config("API_HOST", default="0.0.0.0")
 API_PORT: int = config("API_PORT", default="5000", cast=int)
 
+CELERY_PROMETHEUS_PORT: int = config("CELERY_PROMETHEUS_PORT", default=6666, cast=int)
+
 CACHE_ENABLED: bool = config("CACHE_ENABLED", cast=bool, default=True)
 
 MAX_ISO_DATE_BACKWARD_DIFF: int = config("MAX_ISO_DATE_BACKWARD_DIFF", cast=int, default=180)

--- a/immuni_common/monitoring/core.py
+++ b/immuni_common/monitoring/core.py
@@ -28,6 +28,7 @@ class Subsystem(Enum):
 
     API = "api"
     BUILD = "build"
+    CELERY = "celery"
 
 
 # NOTE: Using Gauge since Info does not work in a Prometheus multiprocess setup.


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR exposes an HTTP server on the specified CELERY_PROMETHEUS_PORT.
Before this, the metrics were populated, yet unquerable from the outside.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

