### PR TITLE
fix(managers): allow MSs to have specific arguments

### DIFF
--- a/immuni_common/core/managers.py
+++ b/immuni_common/core/managers.py
@@ -10,6 +10,7 @@
 #  GNU Affero General Public License for more details.
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any
 
 
 class BaseManagers:
@@ -20,14 +21,18 @@ class BaseManagers:
     implement them all.
     """
 
-    async def initialize(self) -> None:
+    async def initialize(self, **kwargs: Any) -> None:
         """
         Initialize managers on demand.
         To be overridden by subclasses, if needed.
+
+        :param kwargs: the additional keyword arguments the subclasses may need.
         """
 
-    async def teardown(self) -> None:
+    async def teardown(self, **kwargs: Any) -> None:
         """
         Perform teardown actions (e.g., close open connections).
         To be overridden by subclasses, if needed.
+
+        :param kwargs: the additional keyword arguments the subclasses may need.
         """


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Since _immuni-backend-analytics_ required an additional argument for its `managers.initialize`, the superclass interface is changed so as to be more flexible to any future change. The same logic follows the change to the `managers.teardown` method.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

