### PR TITLE
feat(celery): add common string to crontab utility

### DIFF
--- a/immuni_common/celery.py
+++ b/immuni_common/celery.py
@@ -21,10 +21,21 @@ from celery import Celery
 from celery.schedules import crontab
 from celery.signals import after_setup_logger
 from celery.task import Task
+from croniter import croniter
 
 from immuni_common.core import config
 from immuni_common.helpers.logging import setup_celery_logger
 from immuni_common.helpers.utils import dense_dict, modules_in_package
+
+
+def string_to_crontab(crontab_string: str) -> crontab:
+    """
+    Parse a crontab string into a crontab object.
+
+    :param crontab_string: the crontab string to parse.
+    :return: the parsed crontab object.
+    """
+    return crontab(*[",".join(map(str, x)) for x in croniter(crontab_string).expanded])
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Both _immuni-backend-exposure-ingestion_ and _immuni-backend-analytics_ would use a utility to convert a crontab string to a crontab object.
The method is then moved to common.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

