### PR TITLE
feat(mypy): add certvalidator to ignored missing imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -14,5 +14,5 @@ ignore_missing_imports = True
 [mypy-mongoengine.*,extras_mongoengine.*,bson.*,sqlalchemy.*,alembic.*,freezegun.*,pymongo.*]
 ignore_missing_imports = True
 
-[mypy-celery.*,_pytest.*,ecdsa.*,responses.*,pythonjsonlogger.*,gunicorn.*]
+[mypy-celery.*,_pytest.*,ecdsa.*,responses.*,pythonjsonlogger.*,gunicorn.*,certvalidator.*]
 ignore_missing_imports = True


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Ignore missing imports from `certvalidator`.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

