### PR TITLE
feat: add handle_dummy_requests decorator

### DIFF
--- a/immuni_common/core/config.py
+++ b/immuni_common/core/config.py
@@ -35,3 +35,6 @@ CACHE_ENABLED: bool = config("CACHE_ENABLED", cast=bool, default=True)
 
 MAX_ISO_DATE_BACKWARD_DIFF: int = config("MAX_ISO_DATE_BACKWARD_DIFF", cast=int, default=180)
 MAX_ROLLING_PERIOD: int = config("MAX_ROLLING_PERIOD", cast=int, default=1000)
+
+DUMMY_REQUEST_TIMEOUT_MILLIS: int = config("DUMMY_REQUEST_TIMEOUT_MILLIS", cast=int, default=150)
+DUMMY_REQUEST_TIMEOUT_SIGMA: int = config("DUMMY_REQUEST_TIMEOUT_SIGMA", cast=int, default=20)

--- a/immuni_common/helpers/sanic.py
+++ b/immuni_common/helpers/sanic.py
@@ -10,6 +10,7 @@
 #  GNU Affero General Public License for more details.
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 import asyncio
 import json
 import random
@@ -208,6 +209,7 @@ def handle_dummy_requests(
 ]:
     """
     Decorator that allows handling dummy requests.
+
     :param responses: A list of WeightedPair, where the payload is the response
      to be returned with the given weight. The decorator will pick a random
      response based on the given weights.

--- a/immuni_common/helpers/sanic.py
+++ b/immuni_common/helpers/sanic.py
@@ -208,7 +208,7 @@ def handle_dummy_requests(
     Callable[..., Coroutine[Any, Any, HTTPResponse]],
 ]:
     """
-    Decorator that allows handling dummy requests.
+    Decorator that allows the system to handle dummy requests.
 
     :param responses: A list of WeightedPair, where the payload is the response
      to be returned with the given weight. The decorator will pick a random

--- a/immuni_common/helpers/utils.py
+++ b/immuni_common/helpers/utils.py
@@ -13,7 +13,7 @@
 
 import os
 import pkgutil
-from secrets import randbelow
+import random
 from types import ModuleType
 from typing import Any, Dict, List, NamedTuple
 
@@ -77,11 +77,6 @@ def weighted_random(pairs: List[WeightedPair]) -> Any:
 
     :param pairs: The list of WeightedPair to pick the random value from.
     """
-    pairs = [p for p in pairs if p.weight > 0]
-    total = sum(pair.weight for pair in pairs)
-    choice = randbelow(total)
-    for (weight, value) in pairs:
-        choice -= weight
-        if choice <= 0:
-            return value
-    raise RuntimeError("Got to the end of a weighted_random. This should never happen.")
+    return random.choices(
+        population=tuple(p.payload for p in pairs), weights=tuple(p.weight for p in pairs), k=1,
+    )[0]

--- a/immuni_common/helpers/utils.py
+++ b/immuni_common/helpers/utils.py
@@ -72,7 +72,10 @@ class WeightedPair(NamedTuple):
 
 def weighted_random(pairs: List[WeightedPair]) -> Any:
     """
-    Returns the value associated with
+    Returns one of the values in the WeightedPair list randomly based on the
+    weights defined in the given WeightedPair list.
+
+    :param pairs: The list of WeightedPair to pick the random value from.
     """
     pairs = [p for p in pairs if p.weight > 0]
     total = sum(pair.weight for pair in pairs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ exclude = '''
 '''
 
 [tool.pylint.FORMAT]
-good-names = "f,T"
+good-names = "f,T,mu"
 
 [tool.pylint.MASTER]
 load-plugins = "pylint_mongoengine"

--- a/tests/test_helpers/test_dummy_requests.py
+++ b/tests/test_helpers/test_dummy_requests.py
@@ -7,7 +7,7 @@ from sanic.request import Request
 from sanic.response import HTTPResponse
 
 from immuni_common.helpers.sanic import handle_dummy_requests
-from immuni_common.helpers.utils import WeightedPair
+from immuni_common.helpers.utils import WeightedPayload
 
 
 @pytest.mark.parametrize(
@@ -29,10 +29,10 @@ async def test_dummy_endpoints_simple(
     @sanic.route("/dummy")
     @handle_dummy_requests(
         [
-            WeightedPair(
+            WeightedPayload(
                 weight=bad_request_weight, payload=HTTPResponse(status=HTTPStatus.BAD_REQUEST)
             ),
-            WeightedPair(
+            WeightedPayload(
                 weight=not_found_weight, payload=HTTPResponse(status=HTTPStatus.NOT_FOUND)
             ),
         ]

--- a/tests/test_helpers/test_dummy_requests.py
+++ b/tests/test_helpers/test_dummy_requests.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from typing import Tuple
 
 import pytest
 from pytest_sanic.utils import TestClient
@@ -12,7 +11,7 @@ from immuni_common.helpers.utils import WeightedPair
 
 
 @pytest.mark.parametrize(
-    "conf",
+    "bad_request_weight, not_found_weight, expected_status",
     [
         (0, 1, HTTPStatus.NOT_FOUND),
         (1, 0, HTTPStatus.BAD_REQUEST),
@@ -21,10 +20,12 @@ from immuni_common.helpers.utils import WeightedPair
     ],
 )
 async def test_dummy_endpoints_simple(
-    sanic: Sanic, conf: Tuple[int, int, HTTPStatus], client: TestClient
+    sanic: Sanic,
+    bad_request_weight: int,
+    not_found_weight: int,
+    expected_status: HTTPStatus,
+    client: TestClient,
 ) -> None:
-    bad_request_weight, not_found_weight, expected_status = conf
-
     @sanic.route("/dummy")
     @handle_dummy_requests(
         [

--- a/tests/test_helpers/test_dummy_requests.py
+++ b/tests/test_helpers/test_dummy_requests.py
@@ -1,0 +1,46 @@
+from http import HTTPStatus
+from typing import Tuple
+
+import pytest
+from pytest_sanic.utils import TestClient
+from sanic import Sanic
+from sanic.request import Request
+from sanic.response import HTTPResponse
+
+from immuni_common.helpers.sanic import handle_dummy_requests
+from immuni_common.helpers.utils import WeightedPair
+
+
+@pytest.mark.parametrize(
+    "conf",
+    [
+        (0, 1, HTTPStatus.NOT_FOUND),
+        (1, 0, HTTPStatus.BAD_REQUEST),
+        (0, 4, HTTPStatus.NOT_FOUND),
+        (10, 0, HTTPStatus.BAD_REQUEST),
+    ],
+)
+async def test_dummy_endpoints_simple(
+    sanic: Sanic, conf: Tuple[int, int, HTTPStatus], client: TestClient
+) -> None:
+    bad_request_weight, not_found_weight, expected_status = conf
+
+    @sanic.route("/dummy")
+    @handle_dummy_requests(
+        [
+            WeightedPair(
+                weight=bad_request_weight, payload=HTTPResponse(status=HTTPStatus.BAD_REQUEST)
+            ),
+            WeightedPair(
+                weight=not_found_weight, payload=HTTPResponse(status=HTTPStatus.NOT_FOUND)
+            ),
+        ]
+    )
+    async def dummy(request: Request) -> HTTPResponse:
+        return HTTPResponse(status=HTTPStatus.OK)
+
+    response = await client.get("/dummy", headers={"Immuni-Dummy-Data": "0"})
+    assert response.status == HTTPStatus.OK
+
+    response = await client.get("/dummy", headers={"Immuni-Dummy-Data": "1"})
+    assert response.status == expected_status


### PR DESCRIPTION
## Description

This PR adds the 'handle_dummy_requests' decorator, which is capable of handling all dummy requests across the different microservices.

## Checklist

- [X] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket: