### PR TITLE
Feature/handle dummy requests exceptions

### DIFF
--- a/immuni_common/helpers/sanic.py
+++ b/immuni_common/helpers/sanic.py
@@ -27,7 +27,7 @@ from sanic.response import HTTPResponse
 from sanic_openapi import doc
 
 from immuni_common.core import config
-from immuni_common.core.exceptions import ImmuniException, SchemaValidationException
+from immuni_common.core.exceptions import ImmuniException, SchemaValidationException, ApiException
 from immuni_common.helpers.utils import WeightedPayload, weighted_random
 from immuni_common.models.enums import Location
 from immuni_common.models.marshmallow.fields import IntegerBoolField
@@ -197,7 +197,7 @@ async def wait_configured_time(mu: float, sigma: float) -> None:
 
 
 def handle_dummy_requests(
-    responses: List[WeightedPayload[HTTPResponse]],
+    responses: List[WeightedPayload[Union[HTTPResponse, ApiException]]],
 ) -> Callable[
     [Callable[..., Coroutine[Any, Any, HTTPResponse]]],
     Callable[..., Coroutine[Any, Any, HTTPResponse]],
@@ -207,7 +207,8 @@ def handle_dummy_requests(
 
     :param responses: A list of WeightedPair, where the payload is the response
      to be returned with the given weight. The decorator will pick a random
-     response based on the given weights.
+     response based on the given weights. Payloads can be HTTPResponse or ApiException.
+     If the payload is an ApiException it will simply be raised.
     :return: The decorated function.
     """
 
@@ -226,7 +227,10 @@ def handle_dummy_requests(
                 await wait_configured_time(
                     mu=config.DUMMY_REQUEST_TIMEOUT_MILLIS, sigma=config.DUMMY_REQUEST_TIMEOUT_SIGMA
                 )
-                return weighted_random(responses)
+                selected_response = weighted_random(responses)
+                if isinstance(selected_response, ApiException):
+                    raise selected_response
+                return selected_response
             return await f(*args, **kwargs)
 
         return _wrapper

--- a/immuni_common/helpers/sanic.py
+++ b/immuni_common/helpers/sanic.py
@@ -27,7 +27,7 @@ from sanic.response import HTTPResponse
 from sanic_openapi import doc
 
 from immuni_common.core import config
-from immuni_common.core.exceptions import ImmuniException, SchemaValidationException, ApiException
+from immuni_common.core.exceptions import ApiException, ImmuniException, SchemaValidationException
 from immuni_common.helpers.utils import WeightedPayload, weighted_random
 from immuni_common.models.enums import Location
 from immuni_common.models.marshmallow.fields import IntegerBoolField

--- a/immuni_common/helpers/utils.py
+++ b/immuni_common/helpers/utils.py
@@ -72,7 +72,7 @@ class WeightedPayload(Generic[T]):
     payload: T
 
 
-def weighted_random(pairs: List[WeightedPayload]) -> T:
+def weighted_random(pairs: List[WeightedPayload[T]]) -> T:
     """
     Returns one of the values in the WeightedPair list randomly based on the
     weights defined in the given WeightedPair list.

--- a/tests/test_helpers/test_dummy_requests.py
+++ b/tests/test_helpers/test_dummy_requests.py
@@ -6,6 +6,7 @@ from sanic import Sanic
 from sanic.request import Request
 from sanic.response import HTTPResponse
 
+from immuni_common.core.exceptions import NoBatchesException
 from immuni_common.helpers.sanic import handle_dummy_requests
 from immuni_common.helpers.utils import WeightedPayload
 
@@ -32,9 +33,7 @@ async def test_dummy_endpoints_simple(
             WeightedPayload(
                 weight=bad_request_weight, payload=HTTPResponse(status=HTTPStatus.BAD_REQUEST)
             ),
-            WeightedPayload(
-                weight=not_found_weight, payload=HTTPResponse(status=HTTPStatus.NOT_FOUND)
-            ),
+            WeightedPayload(weight=not_found_weight, payload=NoBatchesException()),
         ]
     )
     async def dummy(request: Request) -> HTTPResponse:


### PR DESCRIPTION
## Description

If one of the responses of `handle_dummy_requests` were an exception, the response had to be listed as an explicit HTTPResponse, therefore effectively duplicating the exception handling code. By allowing handle_dummy_request to raise exceptions we make both the code more readable and avoid duplication.

## Checklist

- [X] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket: