### PR TITLE
fix(celery): silence monitoring safe exception

### DIFF
--- a/immuni_common/celery.py
+++ b/immuni_common/celery.py
@@ -131,7 +131,13 @@ class CeleryApp(Celery):
             self.conf.task_routes = self.__routes_function()
 
         monitoring_registry = initialize_monitoring()
-        start_http_server(port=config.CELERY_PROMETHEUS_PORT, registry=monitoring_registry)
+        try:
+            start_http_server(port=config.CELERY_PROMETHEUS_PORT, registry=monitoring_registry)
+        except OSError as exception:
+            # More than one Celery is running on the same machine, so it is enough that one of them
+            # starts the monitoring server.
+            if "Address already in use" not in str(exception):
+                raise
 
     def gen_task_name(self, name: str, module: str) -> str:
         """


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR silences an exception thrown when starting the monitoring server after configuring Celery.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
