### PR TITLE
feat(sanic): prevent caching of status and metrics endpoints

### DIFF
--- a/immuni_common/sanic.py
+++ b/immuni_common/sanic.py
@@ -27,6 +27,7 @@ from sanic_openapi import doc, swagger_blueprint
 from immuni_common.core import config
 from immuni_common.core.exceptions import ApiException
 from immuni_common.core.managers import BaseManagers
+from immuni_common.helpers.cache import cache
 from immuni_common.helpers.logging import get_sanic_logger_config
 from immuni_common.helpers.sanic import json_response
 from immuni_common.models.enums import Environment
@@ -68,12 +69,14 @@ def create_app(
     @app.route("/")
     @doc.summary("Health check.")
     @doc.response(HTTPStatus.OK.value, "Ok", description="The server is running ok.")
+    @cache(no_store=True)
     async def health_check(request: Request) -> HTTPResponse:
         return HTTPResponse(status=HTTPStatus.OK.value)
 
     # TODO: Evaluate whether to expose it over another port.
     @app.route("/metrics")
     @doc.summary("Expose Prometheus metrics.")
+    @cache(no_store=True)
     def metrics(request: Request) -> HTTPResponse:
         latest_metrics = prometheus_client.generate_latest(monitoring_registry)
         return HTTPResponse(


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Prevent caching on `/` and `/metrics` endpoints.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #29 
