### PR TITLE
fix: allow attenuation duration list with length 4

### DIFF
--- a/immuni_common/models/marshmallow/fields.py
+++ b/immuni_common/models/marshmallow/fields.py
@@ -35,7 +35,7 @@ class AttenuationDurations(List):
         super().__init__(
             Integer(validate=Range(min=0, max=sys.maxsize)),
             required=True,
-            validate=Length(min=3, max=3),
+            validate=Length(min=3, max=4),
         )
 
 


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

At least in iOS 13.7 the list can be of 4 elements. This PR relaxes the strict check of only 3 elements being allowed, allowing 4 as well.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

