### PR TITLE
fix(sanic): make the metrics endpoint async

### DIFF
--- a/immuni_common/sanic.py
+++ b/immuni_common/sanic.py
@@ -77,7 +77,7 @@ def create_app(
     @app.route("/metrics")
     @doc.summary("Expose Prometheus metrics.")
     @cache(no_store=True)
-    def metrics(request: Request) -> HTTPResponse:
+    async def metrics(request: Request) -> HTTPResponse:
         latest_metrics = prometheus_client.generate_latest(monitoring_registry)
         return HTTPResponse(
             body=latest_metrics.decode("utf-8"),


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Have the endpoint methods async, so as to properly use the cache decorator for cache-control headers injection.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

