### PR TITLE
feat(api): custom uvicorn worker

### DIFF
--- a/immuni_common/uvicorn.py
+++ b/immuni_common/uvicorn.py
@@ -1,0 +1,29 @@
+#  Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
+#  Please refer to the AUTHORS file for more information.
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU Affero General Public License for more details.
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+from uvicorn.workers import UvicornWorker
+
+
+class ImmuniUvicornWorker(UvicornWorker):
+    """
+    Custom worker setting lifespan=on to fail over exceptions raised within the worker startup.
+
+    For instance, without this, an exception triggered during the managers initialization is
+    never caught.
+
+    NOTE: This lifespan option cannot be passed through the command line of gunicorn since the
+     latter does not support it.
+    """
+
+    CONFIG_KWARGS = dict(lifespan="on")
+

--- a/immuni_common/uvicorn.py
+++ b/immuni_common/uvicorn.py
@@ -26,4 +26,3 @@ class ImmuniUvicornWorker(UvicornWorker):
     """
 
     CONFIG_KWARGS = dict(lifespan="on")
-

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,3 +16,6 @@ ignore_missing_imports = True
 
 [mypy-celery.*,_pytest.*,ecdsa.*,responses.*,pythonjsonlogger.*,gunicorn.*,certvalidator.*]
 ignore_missing_imports = True
+
+[mypy-uvicorn.*]
+ignore_missing_imports = True


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Custom worker setting lifespan=on to fail over exceptions raised within the worker startup.

For instance, without this, an exception triggered during the managers initialization is never caught.

NOTE: This lifespan option cannot be passed through the command line of gunicorn since the latter does not support it.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

