### PR TITLE
feat: move config to common to later use it in two microservices

### DIFF
--- a/immuni_common/core/config.py
+++ b/immuni_common/core/config.py
@@ -35,6 +35,8 @@ CELERY_PROMETHEUS_PORT: int = config("CELERY_PROMETHEUS_PORT", default=6666, cas
 
 CACHE_ENABLED: bool = config("CACHE_ENABLED", cast=bool, default=True)
 
+MAX_ALLOWED_BUILD: int = config("MAX_ALLOWED_BUILD", cast=int, default=20_000)
+
 MAX_ISO_DATE_BACKWARD_DIFF: int = config("MAX_ISO_DATE_BACKWARD_DIFF", cast=int, default=180)
 MAX_ROLLING_PERIOD: int = config("MAX_ROLLING_PERIOD", cast=int, default=1000)
 


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Move a configuration used by both analytics and settings microservices.

As a follow-up, the two services will remove their own config in favour of using this one.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
