### PR TITLE
fix: add mypy_path for common to support poetry upgrade

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,7 @@ no_implicit_optional=True
 warn_redundant_casts=True
 warn_unused_ignores=True
 check_untyped_defs=True
+mypy_path=common
 
 [mypy-aioredis.*,decouple.*,sanic.*,sanic_openapi.*,pytest.*,pytest_sanic.*,prometheus_client.*]
 ignore_missing_imports = True


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Not having this configuration prevents mypy from running properly in the different microservices.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

