### PR TITLE
fix(trl): adapt to latest documentation

### DIFF
--- a/immuni_common/models/enums.py
+++ b/immuni_common/models/enums.py
@@ -116,3 +116,4 @@ class TransmissionRiskLevel(Enum):
     SELF_REPORT = 5
     NEGATIVE_CASE = 6
     RECURSIVE_CASE = 7
+    highest = 8  # TODO: remove after migrating Mongo document to use CONFIRMED_TEST_HIGH

--- a/immuni_common/models/enums.py
+++ b/immuni_common/models/enums.py
@@ -108,12 +108,11 @@ class TransmissionRiskLevel(Enum):
     See https://developer.apple.com/documentation/exposurenotification/enexposureinfo/3583716-transmissionrisklevel#discussion  # noqa: E501, pylint: disable=line-too-long
     """
 
-    # TODO: Use all uppercase names. It may require a database migration.
-    unused_custom = 0
-    confirmed_test_low = 1
-    confirmed_test_standard = 2
-    confirmed_test_high = 3
-    confirmed_clinical_diagnosis = 4
-    self_report = 5
-    negative_case = 6
-    recursive_case = 7
+    UNUSED_CUSTOM = 0
+    CONFIRMED_TEST_LOW = 1
+    CONFIRMED_TEST_STANDARD = 2
+    CONFIRMED_TEST_HIGH = 3
+    CONFIRMED_CLINICAL_DIAGNOSIS = 4
+    SELF_REPORT = 5
+    NEGATIVE_CASE = 6
+    RECURSIVE_CASE = 7

--- a/immuni_common/models/enums.py
+++ b/immuni_common/models/enums.py
@@ -103,15 +103,17 @@ class Platform(Enum):
 class TransmissionRiskLevel(Enum):
     """
     Enumeration of the different transmission risk levels.
+
+    Taken from the official Apple documentation.
+    See https://developer.apple.com/documentation/exposurenotification/enexposureinfo/3583716-transmissionrisklevel#discussion  # noqa: E501, pylint: disable=line-too-long
     """
 
     # TODO: Use all uppercase names. It may require a database migration.
-    none = 0
-    lowest = 1
-    low = 2
-    low_medium = 3
-    medium = 4
-    medium_high = 5
-    high = 6
-    very_high = 7
-    highest = 8
+    unused_custom = 0
+    confirmed_test_low = 1
+    confirmed_test_standard = 2
+    confirmed_test_high = 3
+    confirmed_clinical_diagnosis = 4
+    self_report = 5
+    negative_case = 6
+    recursive_case = 7

--- a/tests/test_models/test_batch_file.py
+++ b/tests/test_models/test_batch_file.py
@@ -44,7 +44,7 @@ def batch_files() -> List[BatchFile]:
                     keys=[
                         TemporaryExposureKey(
                             key_data=generate_random_key_data(),
-                            transmission_risk_level=TransmissionRiskLevel.highest,
+                            transmission_risk_level=TransmissionRiskLevel.confirmed_test_high,
                             rolling_start_number=int(
                                 datetime.utcnow().timestamp()
                                 / timedelta(minutes=10).total_seconds()

--- a/tests/test_models/test_batch_file.py
+++ b/tests/test_models/test_batch_file.py
@@ -44,7 +44,7 @@ def batch_files() -> List[BatchFile]:
                     keys=[
                         TemporaryExposureKey(
                             key_data=generate_random_key_data(),
-                            transmission_risk_level=TransmissionRiskLevel.confirmed_test_high,
+                            transmission_risk_level=TransmissionRiskLevel.CONFIRMED_TEST_HIGH,
                             rolling_start_number=int(
                                 datetime.utcnow().timestamp()
                                 / timedelta(minutes=10).total_seconds()

--- a/tests/test_models/test_batch_file_eu.py
+++ b/tests/test_models/test_batch_file_eu.py
@@ -44,7 +44,7 @@ def batch_files_eu() -> List[BatchFileEu]:
                     keys=[
                         TemporaryExposureKey(
                             key_data=generate_random_key_data_eu(),
-                            transmission_risk_level=TransmissionRiskLevel.highest,
+                            transmission_risk_level=TransmissionRiskLevel.confirmed_test_high,
                             rolling_start_number=int(
                                 datetime.utcnow().timestamp()
                                 / timedelta(minutes=10).total_seconds()

--- a/tests/test_models/test_batch_file_eu.py
+++ b/tests/test_models/test_batch_file_eu.py
@@ -44,7 +44,7 @@ def batch_files_eu() -> List[BatchFileEu]:
                     keys=[
                         TemporaryExposureKey(
                             key_data=generate_random_key_data_eu(),
-                            transmission_risk_level=TransmissionRiskLevel.confirmed_test_high,
+                            transmission_risk_level=TransmissionRiskLevel.CONFIRMED_TEST_HIGH,
                             rolling_start_number=int(
                                 datetime.utcnow().timestamp()
                                 / timedelta(minutes=10).total_seconds()


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

In this PR, we align the transmission risk levels to the one recommended by [the official Apple documentation](https://developer.apple.com/documentation/exposurenotification/enexposureinfo/3583716-transmissionrisklevel#discussion).

Given the current equal weight being given to every single option, nothing should change GAEN-wise.
For this reason, we at least try to align with the one semantically closer to what we intend doing code-wise, aka setting it to the highest risk level in immuni-exposure-ingestion.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-common/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
